### PR TITLE
Snap intervals for specific days of week

### DIFF
--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -1,6 +1,8 @@
 import * as dateFn from 'date-fns';
 import { Token, TokenType } from '../token';
 
+const daysOfWeek = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
 export interface Expression {
   token: Token;
 
@@ -119,6 +121,16 @@ export class SnapExpression implements Expression {
           case 'w':
           case 'bw':
             return dateFn.startOfWeek(date);
+          case 'mon':
+          case 'tue':
+          case 'wed':
+          case 'thu':
+          case 'fri':
+          case 'sat':
+          case 'sun': {
+            const weekDayOrdinal = daysOfWeek.indexOf(this.modifier);
+            return dateFn.startOfWeek(date, { weekStartsOn: weekDayOrdinal });
+          }
           case 'M':
             return dateFn.startOfMonth(date);
         }
@@ -142,6 +154,16 @@ export class SnapExpression implements Expression {
               return date;
             }
             return dateFn.endOfDay(dateFn.addDays(dateFn.startOfWeek(date), 5));
+          }
+          case 'mon':
+          case 'tue':
+          case 'wed':
+          case 'thu':
+          case 'fri':
+          case 'sat':
+          case 'sun': {
+            const weekDayOrdinal = (daysOfWeek.indexOf(this.modifier) + 1) % 7;
+            return dateFn.endOfWeek(date, { weekStartsOn: weekDayOrdinal });
           }
         }
         break;
@@ -168,7 +190,10 @@ export namespace AmountModifiers {
   }
 }
 export namespace SnapModifiers {
-  const values: string[] = ['s', 'm', 'h', 'd', 'w', 'bw', 'M'];
+  const values: string[] = [
+    's', 'm', 'h', 'd', 'w', 'bw', 'M',
+    'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun',
+  ];
 
   export const valuesString = `(${values.map(v => `"${v}"`).join(',')})`;
 

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -129,7 +129,12 @@ export class SnapExpression implements Expression {
           case 'sat':
           case 'sun': {
             const weekDayOrdinal = daysOfWeek.indexOf(this.modifier);
-            return dateFn.startOfWeek(date, { weekStartsOn: weekDayOrdinal });
+            const todayOrdinal = dateFn.getDay(date);
+            // Unfortunately JavaScript gets modular algebra wrong.
+            // -1 mod 7 ≡ 6, but for JavaScript, -1 % 7 = -1. So to get a 6,
+            // you have to do stuff like this.
+            const delta = ((todayOrdinal - weekDayOrdinal) % 7 + 7) % 7;
+            return dateFn.subDays(date, delta);
           }
           case 'M':
             return dateFn.startOfMonth(date);
@@ -162,8 +167,13 @@ export class SnapExpression implements Expression {
           case 'fri':
           case 'sat':
           case 'sun': {
-            const weekDayOrdinal = (daysOfWeek.indexOf(this.modifier) + 1) % 7;
-            return dateFn.endOfWeek(date, { weekStartsOn: weekDayOrdinal });
+            const weekDayOrdinal = daysOfWeek.indexOf(this.modifier);
+            const todayOrdinal = dateFn.getDay(date);
+            // Unfortunately JavaScript gets modular algebra wrong.
+            // -1 mod 7 ≡ 6, but for JavaScript, -1 % 7 = -1. So to get a 6,
+            // you have to do stuff like this.
+            const delta = ((weekDayOrdinal - todayOrdinal) % 7 + 7) % 7;
+            return dateFn.addDays(date, delta);
           }
         }
         break;

--- a/src/lexer/lexer.spec.ts
+++ b/src/lexer/lexer.spec.ts
@@ -17,7 +17,7 @@ describe('Lexer', () => {
   });
 
   it('Lexer.nextToken tokenize ok', () => {
-    const input = 'now-1h/h@M+2w/bw-3s-49d/m';
+    const input = 'now-1h/h@M+2w/bw+2d/mon-3s-49d/m';
     const lexer = new Lexer(input);
     const expected = [
       [TokenType.NOW, 'now'],
@@ -33,6 +33,11 @@ describe('Lexer', () => {
       [TokenType.MODIFIER, 'w'],
       [TokenType.SLASH, '/'],
       [TokenType.MODIFIER, 'bw'],
+      [TokenType.PLUS, '+'],
+      [TokenType.NUMBER, '2'],
+      [TokenType.MODIFIER, 'd'],
+      [TokenType.SLASH, '/'],
+      [TokenType.MODIFIER, 'mon'],
       [TokenType.MINUS, '-'],
       [TokenType.NUMBER, '3'],
       [TokenType.MODIFIER, 's'],

--- a/src/parser/parser.spec.ts
+++ b/src/parser/parser.spec.ts
@@ -24,7 +24,7 @@ describe('Parser', () => {
   }
 
   it('parse', () => {
-    const input = 'now-1h/h@M+2w/bw-3s-49d/m';
+    const input = 'now-1h/h@M+2w/bw+2d/thu-3s-49d/m+5d@mon';
     const lexer = new Lexer(input);
     const parser = new Parser(lexer);
     const nodes = parser.parse();
@@ -35,9 +35,13 @@ describe('Parser', () => {
       { klazz: SnapExpression, modifier: 'M', operator: '@' },
       { klazz: ModifierExpression, amount: 2, modifier: 'w', operator: '+' },
       { klazz: SnapExpression, modifier: 'bw', operator: '/' },
+      { klazz: ModifierExpression, amount: 2, modifier: 'd', operator: '+' },
+      { klazz: SnapExpression, modifier: 'thu', operator: '/' },
       { klazz: ModifierExpression, amount: 3, modifier: 's', operator: '-' },
       { klazz: ModifierExpression, amount: 49, modifier: 'd', operator: '-' },
       { klazz: SnapExpression, modifier: 'm', operator: '/' },
+      { klazz: ModifierExpression, amount: 5, modifier: 'd', operator: '+' },
+      { klazz: SnapExpression, modifier: 'mon', operator: '@' },
     ];
     checkParserErrors(expect, nodes, expected);
   });

--- a/src/token/token.ts
+++ b/src/token/token.ts
@@ -26,6 +26,12 @@ const keywords = {
   w: TokenType.MODIFIER,
   M: TokenType.MODIFIER,
   bw: TokenType.MODIFIER,
+  mon: TokenType.MODIFIER,
+  tue: TokenType.MODIFIER,
+  thu: TokenType.MODIFIER,
+  fri: TokenType.MODIFIER,
+  sat: TokenType.MODIFIER,
+  sun: TokenType.MODIFIER,
 } as Keyword;
 
 export class Token {

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -216,41 +216,53 @@ describe('utils.tokenToDate', () => {
   describe('using a day of the week as a snap', () => {
     // Guide for readers: 2018-06-18 was Monday.
 
-    it('start of last Friday', () => {
+    it('last Friday', () => {
       const actual = format(tokenToDate('now/fri'), dateFormat);
-      const expected = '2018-06-15T00:00:00+00:00';
+      const expected = '2018-06-15T08:39:07+00:00';
       expect(actual).toBe(expected);
     });
 
-    it('start of last Tuesday', () => {
+    it('last Tuesday', () => {
       const actual = format(tokenToDate('now/tue'), dateFormat);
-      const expected = '2018-06-12T00:00:00+00:00';
+      const expected = '2018-06-12T08:39:07+00:00';
       expect(actual).toBe(expected);
     });
 
-    it('start of last Monday', () => {
+    it('last Monday', () => {
       // Since today is Monday, it should snap to today.
       const actual = format(tokenToDate('now/mon'), dateFormat);
-      const expected = '2018-06-18T00:00:00+00:00';
+      const expected = '2018-06-18T08:39:07+00:00';
       expect(actual).toBe(expected);
     });
 
-    it('end of next Friday', () => {
+    it('next Friday', () => {
       const actual = format(tokenToDate('now@fri'), dateFormat);
-      const expected = '2018-06-22T23:59:59+00:00';
+      const expected = '2018-06-22T08:39:07+00:00';
       expect(actual).toBe(expected);
     });
 
-    it('end of next Sunday', () => {
+    it('next Sunday', () => {
       const actual = format(tokenToDate('now@sun'), dateFormat);
-      const expected = '2018-06-24T23:59:59+00:00';
+      const expected = '2018-06-24T08:39:07+00:00';
       expect(actual).toBe(expected);
     });
 
-    it('end of next Monday', () => {
+    it('next Monday', () => {
       // Today is Monday, so it should snap to today.
       const actual = format(tokenToDate('now@mon'), dateFormat);
-      const expected = '2018-06-18T23:59:59+00:00';
+      const expected = '2018-06-18T08:39:07+00:00';
+      expect(actual).toBe(expected);
+    });
+
+    it('snaps to the start of the day when combined', () => {
+      const actual = format(tokenToDate('now-w/mon/d'), dateFormat);
+      const expected = '2018-06-11T00:00:00+00:00';
+      expect(actual).toBe(expected);
+    });
+
+    it('snaps to the end of the day when combined', () => {
+      const actual = format(tokenToDate('now-w@fri@d'), dateFormat);
+      const expected = '2018-06-15T23:59:59+00:00';
       expect(actual).toBe(expected);
     });
   });

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -213,6 +213,48 @@ describe('utils.tokenToDate', () => {
     });
   });
 
+  describe('using a day of the week as a snap', () => {
+    // Guide for readers: 2018-06-18 was Monday.
+
+    it('start of last Friday', () => {
+      const actual = format(tokenToDate('now/fri'), dateFormat);
+      const expected = '2018-06-15T00:00:00+00:00';
+      expect(actual).toBe(expected);
+    });
+
+    it('start of last Tuesday', () => {
+      const actual = format(tokenToDate('now/tue'), dateFormat);
+      const expected = '2018-06-12T00:00:00+00:00';
+      expect(actual).toBe(expected);
+    });
+
+    it('start of last Monday', () => {
+      // Since today is Monday, it should snap to today.
+      const actual = format(tokenToDate('now/mon'), dateFormat);
+      const expected = '2018-06-18T00:00:00+00:00';
+      expect(actual).toBe(expected);
+    });
+
+    it('end of next Friday', () => {
+      const actual = format(tokenToDate('now@fri'), dateFormat);
+      const expected = '2018-06-22T23:59:59+00:00';
+      expect(actual).toBe(expected);
+    });
+
+    it('end of next Sunday', () => {
+      const actual = format(tokenToDate('now@sun'), dateFormat);
+      const expected = '2018-06-24T23:59:59+00:00';
+      expect(actual).toBe(expected);
+    });
+
+    it('end of next Monday', () => {
+      // Today is Monday, so it should snap to today.
+      const actual = format(tokenToDate('now@mon'), dateFormat);
+      const expected = '2018-06-18T23:59:59+00:00';
+      expect(actual).toBe(expected);
+    });
+  });
+
   it('now-1w+3d-6m', () => {
     const actual = tokenToDate('now-1w+3d-6m');
     const delta = (-(7 * 24 * 3600) + 3 * 24 * 3600 - 6 * 60) * 1000;


### PR DESCRIPTION
This pull request addresses issue #1 adding support for business week that starts on a particular day of the week.

Given the explanations in issue #2, support for specifying a particular end of the business week day would be nice, such as `bwFRI` or `bwSAT`. However, considering that a lot of tokens would require to be added (`bwMON`, `bwSUN`, `bwFRI`, `bwSAT`...), why not just adding support for snap a datetoken to a particular day of the week itself?

This pull request adds support for snapping to a day of the week, by issuing modifiers such as `mon`, `tue`, `wed`, `thu`, `fri`, `sat` or `sun`, allowing datetokens to express queries such as the following:

* Next tuesday.
* Last friday at the beginning of the day.
* Next wednesday at the end of the day.
* Last saturday at the end of the day.

## Tasks

- [x] Add the tokens to make the lexer recognise them.
- [x] Add the tokens to the parser so that it can convert them into a valid timestamp.
- [ ] Update the README to document the new tokens.