### PR TITLE
fix: error message on import due to wrong main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
   "name": "datetoken",
   "version": "1.1.0",
   "description": "Parse relative datetime tokens into date objects",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "directories": {
-    "lib": "lib",
     "test": "test"
   },
   "engines": {


### PR DESCRIPTION
Upon importing the module in a project or even running `require(".")` in
a Node.js REPL inside the working directory, the following warning is
visible:

   (node:7) [DEP0128] DeprecationWarning: Invalid 'main' field in
     '/app/node_modules/datetoken/package.json' of './lib/index.js'.
     Please either fix that or report it to the module author

Given that the lib/ directory does not exist in the repository, this
commit will update the package.json so that it uses the proper path. The
package uploaded to NPM is also having the index.js and index.d.ts file
in the repository root.